### PR TITLE
Minor fix on docker-compose exposed port to 8000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: fastapi_app
     build: ./src
     ports:
-      - "8080:80"
+      - "8000:80"
     networks:
       - docker_apis_and_apps
 


### PR DESCRIPTION
Updated exposed port from 8080 to 8000, to match uvicorn server and docker-compose service